### PR TITLE
feat: Add capacities stream

### DIFF
--- a/tap_service_titan/auth.py
+++ b/tap_service_titan/auth.py
@@ -36,5 +36,5 @@ class ServiceTitanAuthenticator(OAuthAuthenticator, metaclass=SingletonMeta):
         return cls(
             stream=stream,
             auth_endpoint=stream.config.get("auth_url"),
-            oauth_scopes="TODO: OAuth Scopes",
+            oauth_scopes="",
         )

--- a/tap_service_titan/streams.py
+++ b/tap_service_titan/streams.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import sys
+from datetime import timedelta, datetime, timezone
 import typing as t
 from functools import cached_property
-
+from singer_sdk.pagination import BaseAPIPaginator
+from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_service_titan.client import (
@@ -1682,3 +1684,89 @@ class ReviewsStream(ServiceTitanStream):
     def path(self) -> str:
         """Return the API path for the stream."""
         return f"/marketingreputation/v2/tenant/{self._tap.config['tenant_id']}/reviews"
+
+
+# Dispatch streams
+
+
+class CapacitiesPaginator(BaseAPIPaginator):
+    """Define paginator for the capacities stream."""
+
+    def __init__(self, start_value: datetime, *args, **kwargs):
+        super().__init__(start_value=start_value, *args, **kwargs)
+        self.end_value = datetime.now(timezone.utc) + timedelta(days=7)
+
+    def has_more(self, response: Response) -> bool:
+        """Check if there are more requests to make."""
+        return self.current_value <= self.end_value
+
+    def get_next(self, response: requests.Response) -> t.Optional[dict]:
+        """Get the next page token."""
+        return self.current_value + timedelta(days=1)
+
+
+class CapacitiesStream(ServiceTitanStream):
+    """Define capacities stream."""
+
+    name = "capacities"
+    primary_keys = ["startUtc", "businessUnitIds"]
+    replication_key = "startUtc"
+    rest_method = "POST"
+    records_jsonpath = "$.availabilities[*]"
+
+    schema = th.PropertiesList(
+        th.Property("start", th.DateTimeType),
+        th.Property("end", th.DateTimeType),
+        th.Property("startUtc", th.DateTimeType),
+        th.Property("endUtc", th.DateTimeType),
+        th.Property("businessUnitIds", th.ArrayType(th.IntegerType)),
+        th.Property("technician_id", th.IntegerType),
+        th.Property("technician_name", th.StringType),
+        th.Property("technician_status", th.StringType),
+        th.Property("technician_hasRequiredSkills", th.BooleanType),
+    ).to_dict()
+
+    def parse_response(self, response: requests.Response) -> t.Iterable[dict]:
+        """Parse the response and return an iterator of result records.
+
+        Args:
+            response: The HTTP ``requests.Response`` object.
+
+        Yields:
+            Each record from the source.
+        """
+        for availability_dict in extract_jsonpath(
+            self.records_jsonpath, input=response.json()
+        ):
+            # We're only looking to get technician availabilities here
+            for unused_key in [
+                "totalAvailability",
+                "openAvailability",
+                "isAvailable",
+                "isExceedingIdealBookingPercentage",
+            ]:
+                availability_dict.pop(unused_key)
+            for technician in availability_dict.pop("technicians"):
+                technician_dict = {
+                    f"technician_{key}": val for key, val in technician.items()
+                }
+                yield {**availability_dict, **technician_dict}
+
+    def get_new_paginator(self) -> CapacitiesPaginator:
+        """Get the paginator."""
+        return CapacitiesPaginator(self.get_starting_timestamp(self.context))
+
+    def prepare_request_payload(
+        self, context: dict | None, next_page_token: t.Any | None
+    ) -> dict | None:
+        """Prepare the request payload."""
+        return {
+            "startsOnOrAfter": next_page_token.isoformat(),
+            "endsOnOrBefore": (next_page_token + timedelta(days=1)).isoformat(),
+            "skillBasedAvailability": "false",
+        }
+
+    @cached_property
+    def path(self) -> str:
+        """Return the API path for the stream."""
+        return f"/dispatch/v2/tenant/{self._tap.config['tenant_id']}/capacity"

--- a/tap_service_titan/streams.py
+++ b/tap_service_titan/streams.py
@@ -1709,7 +1709,7 @@ class CapacitiesStream(ServiceTitanStream):
     """Define capacities stream."""
 
     name = "capacities"
-    primary_keys = ["startUtc", "businessUnitIds"]
+    primary_keys = ["startUtc", "businessUnitIds", "technician_id"]
     replication_key = "startUtc"
     rest_method = "POST"
     records_jsonpath = "$.availabilities[*]"

--- a/tap_service_titan/tap.py
+++ b/tap_service_titan/tap.py
@@ -54,6 +54,12 @@ class TapServiceTitan(Tap):
             default="https://auth-integration.servicetitan.io/connect/token",
             description="The url for the ServiceTitan OAuth API",
         ),
+        th.Property(
+            "start_date",
+            th.DateTimeType,
+            default="2024-01-01T00:00:00Z",
+            description="The start date for the records to pull.",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> list[streams.ServiceTitanStream]:
@@ -94,6 +100,7 @@ class TapServiceTitan(Tap):
             streams.PurchaseOrderTypesStream(self),
             streams.ReceiptsStream(self),
             streams.ReviewsStream(self),
+            streams.CapacitiesStream(self),
         ]
 
 


### PR DESCRIPTION
This adds a new stream which uses the dispatch capacities endpoint to iteratively search technician availabilities by date range. It's a different pattern than any other endpoint and the data is modeled differently. I've chosen to do some of the cleaning and formatting here in the tap rather than leaving it to be done downstream because capacity data is only really useful for an analytics use case at the technician level like this. Basically, the API itself rolls things up a little bit and this is closer to what a reasonable "raw" data should look like in the context of raw data returned by the more typical GET endpoints in this tap.