### PR TITLE
feat: add custom report streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ A full list of supported settings and capabilities is available by running: `tap
 
 ### Custom Reports
 
+An example of the input for the custom reports array config is below.
+The values can be found in the Service Titan UI when the custom report is created.
+
 ```json
   "custom_reports": [
       {

--- a/README.md
+++ b/README.md
@@ -1,48 +1,72 @@
-# tap-service-titan
+# `tap-service-titan`
 
-`tap-service-titan` is a Singer tap for ServiceTitan.
+ServiceTitan tap class.
 
-Built with the [Meltano Tap SDK](https://sdk.meltano.com) for Singer Taps.
+Built with the [Meltano Singer SDK](https://sdk.meltano.com).
 
-<!--
+## Capabilities
 
-Developer TODO: Update the below as needed to correctly describe the install procedure. For instance, if you do not have a PyPi repo, or if you want users to directly install from your git repo, you can modify this step as appropriate.
+* `catalog`
+* `state`
+* `discover`
+* `about`
+* `stream-maps`
+* `schema-flattening`
+* `batch`
 
-## Installation
+## Supported Python Versions
 
-Install from PyPi:
+* 3.8
+* 3.9
+* 3.10
+* 3.11
+* 3.12
 
-```bash
-pipx install tap-service-titan
-```
+## Settings
 
-Install from GitHub:
+| Setting | Required | Default | Description |
+|:--------|:--------:|:-------:|:------------|
+| client_id | True     | None    | The client ID to use in authenticating. |
+| client_secret | True     | None    | The client secret to use in authenticating. |
+| st_app_key | True     | None    | The app key for the Service Titan app used to authenticate. |
+| tenant_id | True     | None    | Tenant ID to pull records for. |
+| api_url | False    | https://api-integration.servicetitan.io | The url for the ServiceTitan API |
+| auth_url | False    | https://auth-integration.servicetitan.io/connect/token | The url for the ServiceTitan OAuth API |
+| start_date | False    | 2024-01-01T00:00:00Z | The start date for the records to pull. |
+| custom_reports | False    | None    | Custom reports to extract. |
+| stream_maps | False    | None    | Config object for stream maps capability. For more information check out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html). |
+| stream_map_config | False    | None    | User-defined config values to be used within map expressions. |
+| faker_config | False    | None    | Config for the [`Faker`](https://faker.readthedocs.io/en/master/) instance variable `fake` used within map expressions. Only applicable if the plugin specifies `faker` as an addtional dependency (through the `singer-sdk` `faker` extra or directly). |
+| faker_config.seed | False    | None    | Value to seed the Faker generator for deterministic output: https://faker.readthedocs.io/en/master/#seeding-the-generator |
+| faker_config.locale | False    | None    | One or more LCID locale strings to produce localized output for: https://faker.readthedocs.io/en/master/#localization |
+| flattening_enabled | False    | None    | 'True' to enable schema flattening and automatically expand nested properties. |
+| flattening_max_depth | False    | None    | The max depth to flatten schemas. |
+| batch_config | False    | None    |             |
+| batch_config.encoding | False    | None    | Specifies the format and compression of the batch files. |
+| batch_config.encoding.format | False    | None    | Format to use for batch files. |
+| batch_config.encoding.compression | False    | None    | Compression format to use for batch files. |
+| batch_config.storage | False    | None    | Defines the storage layer to use when writing batch files |
+| batch_config.storage.root | False    | None    | Root path to use when writing batch files. |
+| batch_config.storage.prefix | False    | None    | Prefix to use when writing batch files. |
 
-```bash
-pipx install git+https://github.com/ORG_NAME/tap-service-titan.git@main
-```
+A full list of supported settings and capabilities is available by running: `tap-service-titan --about`
 
--->
+### Custom Reports
 
-## Configuration
-
-### Accepted Config Options
-
-<!--
-Developer TODO: Provide a list of config options accepted by the tap.
-
-This section can be created by copy-pasting the CLI output from:
-
-```
-tap-service-titan --about --format=markdown
-```
--->
-
-A full list of supported settings and capabilities for this
-tap is available by running:
-
-```bash
-tap-service-titan --about
+```json
+  "custom_reports": [
+      {
+          "report_category": "accounting",
+          "report_name": "my_custom_accounting_report",
+          "report_id": "123",
+          "parameters": [
+              {
+                  "name": "AsOfDate",
+                  "value": "2024-09-01"
+              }
+          ]
+      }
+  ]
 ```
 
 ### Configure using environment variables
@@ -50,12 +74,6 @@ tap-service-titan --about
 This Singer tap will automatically import any environment variables within the working directory's
 `.env` if the `--config=ENV` is provided, such that config values will be considered if a matching
 environment variable is set either in the terminal context or in the `.env` file.
-
-### Source Authentication and Authorization
-
-<!--
-Developer TODO: If your tap requires special access on the source system, or any special authentication requirements, provide those here.
--->
 
 ## Usage
 
@@ -99,12 +117,6 @@ poetry run tap-service-titan --help
 
 _**Note:** This tap will work in any Singer environment and does not require Meltano.
 Examples here are for convenience and to streamline end-to-end orchestration scenarios._
-
-<!--
-Developer TODO:
-Your project comes with a custom `meltano.yml` project file already created. Open the `meltano.yml` and follow any "TODO" items listed in
-the file.
--->
 
 Next, install Meltano (if you haven't already) and any needed plugins:
 

--- a/tap_service_titan/streams.py
+++ b/tap_service_titan/streams.py
@@ -7,10 +7,12 @@ import typing as t
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
 
+import requests
 from singer_sdk import typing as th  # JSON Schema typing helpers
 from singer_sdk.helpers import types
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.pagination import BaseAPIPaginator
+from singer_sdk.streams.core import REPLICATION_FULL_TABLE
 
 from tap_service_titan.client import (
     ServiceTitanExportStream,
@@ -19,6 +21,7 @@ from tap_service_titan.client import (
 
 if t.TYPE_CHECKING:
     import requests
+    from singer_sdk.streams.rest import _TToken
 
 if sys.version_info >= (3, 9):
     import importlib.resources as importlib_resources
@@ -1666,6 +1669,7 @@ class ReceiptsStream(ServiceTitanStream):
         """Return the API path for the stream."""
         return f"/inventory/v2/tenant/{self._tap.config['tenant_id']}/receipts"
 
+
 class ReturnsStream(ServiceTitanStream):
     """Define returns stream."""
 
@@ -1894,3 +1898,121 @@ class CapacitiesStream(ServiceTitanStream):
     def path(self) -> str:
         """Return the API path for the stream."""
         return f"/dispatch/v2/tenant/{self._tap.config['tenant_id']}/capacity"
+
+
+class CustomReports(ServiceTitanStream):
+    """Define reviews stream."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._report = kwargs.pop("report")
+        super().__init__(
+            *args,
+            **kwargs,
+            name=f"custom_report_{self._report['report_name']}",
+        )
+
+    name = "custom_report"
+    rest_method = "POST"
+    replication_method = REPLICATION_FULL_TABLE
+
+    @staticmethod
+    def _get_datatype(string_type: str) -> th.JSONTypeHelper:
+        mapping = {
+            # String , Number , Boolean , Date , Time
+            "String": th.StringType(),
+            "Number": th.NumberType(),
+            "Boolean": th.BooleanType(),
+            "Date": th.DateType(),
+            "Time": th.StringType(),
+        }
+        return mapping.get(string_type, th.StringType())
+
+    def _get_report_metadata(self) -> dict:
+        report_category = self._report["report_category"]
+        report_id = self._report["report_id"]
+        resp = requests.get(
+            f"{self.url_base}/reporting/v2/tenant/{self.config["tenant_id"]}/report-category/{report_category}/reports/{report_id}?pageSize=5000&page=1",
+            headers={**self.http_headers, **self.authenticator.auth_headers},
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    @cached_property
+    def schema(self) -> dict:
+        """Get schema.
+
+        Returns:
+            JSON Schema dictionary for this stream.
+        """
+        metadata = self._get_report_metadata()
+        msg = f"Available parameters for custom report `{self._report['report_name']}`: {metadata['parameters']}"
+        self.logger.info(msg)
+        properties: list[th.Property] = [
+            th.Property(field["name"], self._get_datatype(field["dataType"]))
+            for field in metadata["fields"]
+        ]
+
+        return th.PropertiesList(*properties).to_dict()
+
+    @cached_property
+    def path(self) -> str:
+        """Return the API path for the stream."""
+        report_category = self._report["report_category"]
+        report_id = self._report["report_id"]
+        return (
+            f"/reporting/v2/tenant/{self._tap.config['tenant_id']}/report-category"
+            f"{report_category}/reports/{report_id}/data"
+        )
+
+    def get_url_params(
+        self,
+        context: dict | None,
+        next_page_token: t.Any | None,  # noqa: ANN401
+    ) -> dict[str, t.Any]:
+        """Return a dictionary of values to be used in URL parameterization.
+
+        Args:
+            context: The stream context.
+            next_page_token: The next page index or value.
+
+        Returns:
+            A dictionary of URL query parameters.
+        """
+        params = super().get_url_params(context, next_page_token)
+        params.pop("modifiedOnOrAfter", "")
+        return params
+
+    def prepare_request_payload(
+        self,
+        context: types.Context | None,
+        next_page_token: _TToken | None,
+    ) -> dict | None:
+        """Prepare the data payload for the REST API request.
+
+        By default, no payload will be sent (return None).
+
+        Developers may override this method if the API requires a custom payload along
+        with the request. (This is generally not required for APIs which use the
+        HTTP 'GET' method.)
+
+        Args:
+            context: Stream partition or context dictionary.
+            next_page_token: Token, page number or any request argument to request the
+                next page of data.
+        """
+        return {"parameters": self._report["parameters"]}
+
+    def parse_response(self, response: requests.Response) -> t.Iterable[dict]:
+        """Parse the response and return an iterator of result records.
+
+        Args:
+            response: The HTTP ``requests.Response`` object.
+
+        Yields:
+            Each record from the source.
+        """
+        resp = response.json()
+        field_names = [field["name"] for field in resp["fields"]]
+        for record in resp["data"]:
+            yield dict(zip(field_names, record))


### PR DESCRIPTION
The tap now accepts a list of custom report configurations that allow the tap to dynamically discover the report schema and request the data. All streams of this form are full table syncs. It also logs the available parameters for ease of use, theres not an easy way for users to look up the parameters that are available and their format i.e. `As Of Date` in the UI needs to be passed as `AsOfDate`.

Refresh the readme with auto settings and sample custom config.