### PR TITLE
fix: handle errors better

### DIFF
--- a/tap_service_titan/client.py
+++ b/tap_service_titan/client.py
@@ -95,7 +95,7 @@ class ServiceTitanBaseStream(RESTStream):
             str: The error message
         """
         default = super().response_error_message(response)
-        if "title" in response.json():
+        if response.content and "title" in response.json():
             title = response.json()["title"]
             return f"{default}. {title}"
         return default


### PR DESCRIPTION
The tap is returning a new error when it tries to do custom error response parsing in some cases. Handle it in a safer way.