### PR TITLE
refactor: improve report performance

### DIFF
--- a/tap_service_titan/streams/reporting.py
+++ b/tap_service_titan/streams/reporting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import typing as t
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
@@ -149,6 +150,7 @@ class CustomReports(ServiceTitanStream):
         """
         params = super().get_url_params(context, next_page_token)
         params.pop("modifiedOnOrAfter", "")
+        params["pageSize"] = 25000
         return params
 
     def prepare_request_payload(
@@ -236,6 +238,6 @@ class CustomReports(ServiceTitanStream):
 
         def _backoff_from_headers(retriable_api_error) -> int:  # noqa: ANN001
             response_headers = retriable_api_error.response.headers
-            return int(response_headers.get("Retry-After", 0))
+            return int(math.ceil(response_headers.get("Retry-After", 0)))
 
         return self.backoff_runtime(value=_backoff_from_headers)


### PR DESCRIPTION
Use max page size for reports since the requests are rate limited. This bumps from 5k to 25k which should reduce requests by 5X. The docs dont define the max but if you exceed it the error response says its 25k max. We have an 80k report that was taking 16 requests at ~25 mins previously which would now take 4 requests ~6 mins. 75% performance improvement.