### PR TITLE
feat: add lookback_window_days config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ The backfill_date_parameter value must be in the parameters list.
   ]
 ```
 
+Optionally add `lookback_window_days` to define the amount of days to lookback when running incrementally.
+This is used to handled retroactively updated data in previously synced reports.
+
+```json
+  "custom_reports": [
+      {
+          "report_category": "accounting",
+          "report_name": "my_custom_accounting_report",
+          "report_id": "123",
+          "backfill_date_parameter": "AsOfDate",
+          "lookback_window_days": 30,
+          "parameters": [
+              {
+                  "name": "AsOfDate",
+                  "value": "2024-09-01"
+              }
+          ]
+      }
+  ]
+```
 ### Configure using environment variables
 
 This Singer tap will automatically import any environment variables within the working directory's

--- a/tap_service_titan/streams/reporting.py
+++ b/tap_service_titan/streams/reporting.py
@@ -70,6 +70,10 @@ class CustomReports(ServiceTitanStream):
         ).date()
         bookmark = self.stream_state.get("replication_key_value")
         if bookmark:
+            if self._report.get("lookback_window_days"):
+                bookmark = bookmark - timedelta(
+                    days=self._report["lookback_window_days"]
+                )
             return max(
                 configured_date_param,
                 datetime.strptime(bookmark, "%Y-%m-%dT%H:%M:%S%z").date(),

--- a/tap_service_titan/streams/reporting.py
+++ b/tap_service_titan/streams/reporting.py
@@ -70,13 +70,13 @@ class CustomReports(ServiceTitanStream):
         ).date()
         bookmark = self.stream_state.get("replication_key_value")
         if bookmark:
-            if self._report.get("lookback_window_days"):
-                bookmark = bookmark - timedelta(
-                    days=self._report["lookback_window_days"]
-                )
+            # Parse to a date and subtract the lookback window days if configured
+            bookmark_dt = datetime.strptime(
+                bookmark, "%Y-%m-%dT%H:%M:%S%z"
+            ).date() - timedelta(days=self._report.get("lookback_window_days", 0))
             return max(
                 configured_date_param,
-                datetime.strptime(bookmark, "%Y-%m-%dT%H:%M:%S%z").date(),
+                bookmark_dt,
             )
         return configured_date_param
 

--- a/tap_service_titan/streams/reporting.py
+++ b/tap_service_titan/streams/reporting.py
@@ -73,7 +73,7 @@ class CustomReports(ServiceTitanStream):
             # Parse to a date and subtract the lookback window days if configured
             bookmark_dt = datetime.strptime(
                 bookmark, "%Y-%m-%dT%H:%M:%S%z"
-            ).date() - timedelta(days=self._report.get("lookback_window_days", 0))
+            ).date() - timedelta(days=self._report["lookback_window_days"])
             return max(
                 configured_date_param,
                 bookmark_dt,

--- a/tap_service_titan/tap.py
+++ b/tap_service_titan/tap.py
@@ -100,7 +100,8 @@ class TapServiceTitan(Tap):
                             "The amount of days to lookback when running incrementally."
                             "This is used to handled retroactively updated data in "
                             "previously synced reports.",
-                        )
+                        ),
+                        default=0,
                     ),
                     th.Property(
                         "parameters",

--- a/tap_service_titan/tap.py
+++ b/tap_service_titan/tap.py
@@ -94,6 +94,15 @@ class TapServiceTitan(Tap):
                         description="The date parameter to use for backfilling. The report will be retrieved for each date until the current date.",  # noqa: E501
                     ),
                     th.Property(
+                        "lookback_window_days",
+                        th.StringType,
+                        description=(
+                            "The amount of days to lookback when running incrementally."
+                            "This is used to handled retroactively updated data in "
+                            "previously synced reports.",
+                        )
+                    ),
+                    th.Property(
                         "parameters",
                         th.ArrayType(
                             th.ObjectType(

--- a/tap_service_titan/tap.py
+++ b/tap_service_titan/tap.py
@@ -95,7 +95,7 @@ class TapServiceTitan(Tap):
                     ),
                     th.Property(
                         "lookback_window_days",
-                        th.StringType,
+                        th.NumberType,
                         description=(
                             "The amount of days to lookback when running incrementally."
                             "This is used to handled retroactively updated data in "


### PR DESCRIPTION
Closes https://github.com/archdotdev/tap-service-titan/issues/71

Adds an optional config that defaults to 0 days. It subtracts from the incremental bookmark but not from the start date so it wont lookback on the initial run, it will use the start_date as provided.