### PR TITLE
chore: Add "active=Any" query param for receipts and returns

### DIFF
--- a/tap_service_titan/streams/inventory.py
+++ b/tap_service_titan/streams/inventory.py
@@ -245,6 +245,25 @@ class ReceiptsStream(ServiceTitanStream):
         ),
     ).to_dict()
 
+    def get_url_params(
+        self,
+        context: dict | None,
+        next_page_token: t.Any | None,  # noqa: ANN401
+    ) -> dict[str, t.Any]:
+        """Return a dictionary of values to be used in URL parameterization.
+
+        Args:
+            context: The stream context.
+            next_page_token: The next page index or value.
+
+        Returns:
+            A dictionary of URL query parameters.
+        """
+        params = super().get_url_params(context, next_page_token)
+        # This endpoint has an undocumented max page size of 500
+        params["active"] = "Any"
+        return params
+
     @cached_property
     def path(self) -> str:
         """Return the API path for the stream."""
@@ -350,6 +369,25 @@ class ReturnsStream(ServiceTitanStream):
             ),
         ),
     ).to_dict()
+
+    def get_url_params(
+        self,
+        context: dict | None,
+        next_page_token: t.Any | None,  # noqa: ANN401
+    ) -> dict[str, t.Any]:
+        """Return a dictionary of values to be used in URL parameterization.
+
+        Args:
+            context: The stream context.
+            next_page_token: The next page index or value.
+
+        Returns:
+            A dictionary of URL query parameters.
+        """
+        params = super().get_url_params(context, next_page_token)
+        # This endpoint has an undocumented max page size of 500
+        params["active"] = "Any"
+        return params
 
     @cached_property
     def path(self) -> str:


### PR DESCRIPTION
See: 
- https://developer.servicetitan.io/api-details/#api=tenant-inventory-v2&operation=Receipts_GetList 
- https://developer.servicetitan.io/api-details/#api=tenant-inventory-v2&operation=Returns_GetList

Only active items are returned by default, this updates to return both active and inactive. 