### PR TITLE
fix: handle non-JSON error responses from Service Titan API

### DIFF
--- a/tap_service_titan/client.py
+++ b/tap_service_titan/client.py
@@ -95,9 +95,16 @@ class ServiceTitanBaseStream(RESTStream):
             str: The error message
         """
         default = super().response_error_message(response)
-        if response.content and "title" in response.json():
-            title = response.json()["title"]
-            return f"{default}. {title}"
+        if response.content:
+            try:
+                json_response = response.json()
+                if "title" in json_response:
+                    title = json_response["title"]
+                    return f"{default}. {title}"
+            except (requests.exceptions.JSONDecodeError, ValueError):
+                # Response content is not valid JSON - log the full content
+                # This helps debug unexpected responses (e.g., HTML error pages)
+                return f"{default}. Response body: {response.text}"
         return default
 
 


### PR DESCRIPTION
## Summary
- Fixes JSONDecodeError when Service Titan returns non-JSON error responses (e.g., HTML error pages on 503 errors)
- Logs the full response body to help diagnose the actual error instead of crashing

## Test plan
- [x] Verify the tap handles 503 errors without crashing
- [x] Check that JSON error responses still extract the "title" field correctly
- [x] Confirm non-JSON responses log the full body for debugging

🤖 Generated with Arch.dev