### PR TITLE
Missing records for adgroup_performance

### DIFF
--- a/tap_service_titan/streams/marketing_ads.py
+++ b/tap_service_titan/streams/marketing_ads.py
@@ -301,6 +301,7 @@ class _PerformanceStream(ServiceTitanStream):
 
         params["fromUtc"] = next_page_token.start.isoformat()
         params["toUtc"] = next_page_token.end.isoformat()
+        params["pageSize"] = 5000
         return params
 
 


### PR DESCRIPTION
Not the best fix as we need to fix the paginator, but this fixes the problem enough for Kings

The tap is using a DateRangePaginator here https://github.com/archdotdev/tap-service-titan/blob/main/tap_service_titan/streams/marketing_ads.py#L278

BUT the big issue is the API is paginated per date range. So  because https://github.com/archdotdev/tap-service-titan/blob/main/tap_service_titan/streams/marketing_ads.py#L301 doesn't have a page_size of something high like 5000 , it's defaulting to a page size of 50, meaning we need to paginate over the results we get back ON TOP of paginating across the dates.

Really we should do the pagination of the stream first, then move on with the Date Range stuff, but this fix is easier right now
