### PR TITLE
fix(accounting,inventory): Handle `0` values in `landedCostMethod` fields

### DIFF
--- a/tap_service_titan/openapi_specs/__init__.py
+++ b/tap_service_titan/openapi_specs/__init__.py
@@ -137,6 +137,16 @@ class ServiceTitanSchema(StreamSchema):
                 "type": "integer",
             }
 
+        if stream.name in ("inventory_bills", "purchase_order_types", "receipts"):
+            # TODO(maintainers): Remove once ServiceTitan fixes this.
+            # API returns integer enum values (e.g. 0) instead of string names.
+            # https://github.com/MeltanoLabs/tap-service-titan/issues/358
+            schema["properties"]["landedCostMethod"]["type"] = [
+                "integer",
+                "string",
+                "null",
+            ]
+
         return schema
 
 

--- a/tests/__snapshots__/test_schema_evolution/test_catalog_changes[inventory_bills].json
+++ b/tests/__snapshots__/test_schema_evolution/test_catalog_changes[inventory_bills].json
@@ -885,6 +885,7 @@
       "landedCostMethod": {
         "description": "",
         "type": [
+          "integer",
           "string",
           "null"
         ]

--- a/tests/__snapshots__/test_schema_evolution/test_catalog_changes[purchase_order_types].json
+++ b/tests/__snapshots__/test_schema_evolution/test_catalog_changes[purchase_order_types].json
@@ -224,6 +224,7 @@
       "landedCostMethod": {
         "description": "",
         "type": [
+          "integer",
           "string",
           "null"
         ]

--- a/tests/__snapshots__/test_schema_evolution/test_catalog_changes[receipts].json
+++ b/tests/__snapshots__/test_schema_evolution/test_catalog_changes[receipts].json
@@ -708,6 +708,7 @@
       "landedCostMethod": {
         "description": "",
         "type": [
+          "integer",
           "string",
           "null"
         ]


### PR DESCRIPTION
See https://github.com/MeltanoLabs/tap-service-titan/issues/358