### PR TITLE
fix: Use non-export technicians endpoint so zoneIds is populated

### DIFF
--- a/tap_service_titan/streams/settings.py
+++ b/tap_service_titan/streams/settings.py
@@ -34,14 +34,19 @@ class BusinessUnitsStream(_BaseSettingsExportStream):
     schema = ServiceTitanSchema(SETTINGS, key="TenantSettings.V2.ExportBusinessUnitResponse")
 
 
-class TechniciansStream(_BaseSettingsExportStream):
-    """Define technicians stream."""
+class TechniciansStream(_BaseSettingsStream, active_any=True):
+    """Define technicians stream.
+
+    Uses the paginated list endpoint rather than /export/technicians: the export
+    feed always returns an empty ``zoneIds`` array, while the list endpoint
+    populates it. Field sets are otherwise identical.
+    """
 
     name = "technicians"
-    path = "/export/technicians"
+    path = "/technicians"
     primary_keys = ("id",)
     replication_key: str = "modifiedOn"
-    schema = ServiceTitanSchema(SETTINGS, key="TenantSettings.V2.ExportTechnicianResponse")
+    schema = ServiceTitanSchema(SETTINGS, key="TenantSettings.V2.TechnicianResponse")
 
 
 class TagTypesStream(_BaseSettingsStream, active_any=True):


### PR DESCRIPTION
Closes #403

## Problem

The `technicians` stream reads `/settings/v2/tenant/{tenant}/export/technicians`, and that export feed always returns `zoneIds: []` even when the technician has zone assignments (details and evidence in #403). Across the 21 tenants we sync, zero of ~5,800 technician records ever landed with zone data.

## Change

`TechniciansStream` now uses the paginated non-export list endpoint `/technicians` (`_BaseSettingsStream`, `active_any=True`), which returns `zoneIds` populated.

## Why this is a safe swap

Verified against a live production tenant, calling both endpoints with the tap's exact request params:

- **Identical record sets** — the list endpoint with `active=Any` returns the same technicians as the export feed, including inactive ones (36/36 on the test tenant).
- **Identical field sets** — a value-level diff shows `zoneIds` is the only field whose values differ between the endpoints.
- **Identical catalog** — `TenantSettings.V2.TechnicianResponse` resolves to the same JSON schema as `ExportTechnicianResponse`; the snapshot tests pass with no snapshot updates.
- **Same replication strategy** — the list endpoint supports `modifiedOnOrAfter`, so the `modifiedOn` bookmark carries over. Existing state remains valid (though consumers who want `zoneIds` backfilled onto previously-synced rows will need one full refresh of this stream).

## Testing

- Full test suite green (129 snapshot subtests, no snapshot changes).
- Live run against a production tenant returns all technicians with `zoneIds` matching the ServiceTitan UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)