### PR TITLE
feat: optionally skip streams the tenant is not entitled to

### DIFF
--- a/tap_service_titan/client.py
+++ b/tap_service_titan/client.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import sys
+import typing as t
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import cached_property
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
 import requests
@@ -30,6 +32,14 @@ if TYPE_CHECKING:
 
 
 DEFAULT_PAGE_SIZE = 5000
+
+
+class StreamNotEntitledError(Exception):
+    """Raised when the tenant is not licensed for the endpoint backing a stream.
+
+    Internal control-flow signal, caught in
+    :meth:`ServiceTitanBaseStream.request_records`. It must not escape the tap.
+    """
 
 
 @dataclass
@@ -198,6 +208,53 @@ class ServiceTitanBaseStream(RESTStream[_TToken]):
                 # This helps debug unexpected responses (e.g., HTML error pages)
                 return f"{default}. Response body: {response.text}"
         return default
+
+    @override
+    def validate_response(self, response: requests.Response) -> None:
+        """Validate the response, translating 403s into a skip when configured.
+
+        ServiceTitan returns 403 when the tenant has not licensed the module
+        backing an endpoint (e.g. Marketing Pro, WBS budget codes). That is a
+        property of the tenant's subscription, not a transient failure, so
+        retrying cannot help. Opting in lets one stream selection be shared
+        across tenants instead of maintaining a bespoke list per tenant.
+
+        Args:
+            response: A :class:`requests.Response` object.
+
+        Raises:
+            StreamNotEntitledError: If the tenant is not entitled to the endpoint
+                and ``skip_unentitled_streams`` is enabled.
+        """
+        if response.status_code == HTTPStatus.FORBIDDEN and self.config.get(
+            "skip_unentitled_streams", False
+        ):
+            raise StreamNotEntitledError(self.response_error_message(response))
+        super().validate_response(response)
+
+    @override
+    def request_records(self, context: Context | None) -> t.Iterable[dict]:
+        """Request records, yielding nothing if the tenant lacks entitlement.
+
+        Ending the generator leaves the stream's bookmark untouched, so a tenant
+        that later licenses the module resumes from where it left off rather
+        than re-syncing from the start date.
+
+        Args:
+            context: Stream partition or context dictionary.
+
+        Yields:
+            Records from the endpoint, or nothing if it returned 403.
+        """
+        try:
+            yield from super().request_records(context)
+        except StreamNotEntitledError as exc:
+            self.logger.warning(
+                "Skipping stream '%s' for tenant %s: not entitled to this endpoint. %s",
+                self.name,
+                self.config.get("tenant_id"),
+                exc,
+            )
 
 
 class ServiceTitanExportStream(ServiceTitanBaseStream):

--- a/tap_service_titan/tap.py
+++ b/tap_service_titan/tap.py
@@ -155,6 +155,18 @@ class TapServiceTitan(Tap):
             ),
             description="Custom reports to extract.",
         ),
+        th.Property(
+            "skip_unentitled_streams",
+            th.BooleanType,
+            default=False,
+            description=(
+                "When true, a stream whose endpoint the tenant is not entitled to "
+                "(HTTP 403) is logged and skipped instead of failing the run. Lets a "
+                "single stream selection be shared across tenants with differing "
+                "ServiceTitan module subscriptions. Off by default: silently skipping "
+                "streams will also mask a genuine loss of OAuth scope."
+            ),
+        ),
     ).to_dict()
 
     @override

--- a/tests/test_unentitled_streams.py
+++ b/tests/test_unentitled_streams.py
@@ -1,0 +1,93 @@
+"""Tests for skipping streams the tenant is not entitled to."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+
+import pytest
+import requests
+from singer_sdk.exceptions import FatalAPIError
+
+from tap_service_titan.streams.pricebook import DiscountsAndFeesStream
+from tap_service_titan.tap import TapServiceTitan
+
+BASE_CONFIG = {
+    "client_id": "id",
+    "client_secret": "secret",
+    "st_app_key": "key",
+    "tenant_id": "123456789",
+    "api_url": "https://api.servicetitan.io",
+    "auth_url": "https://auth.servicetitan.io/connect/token",
+}
+
+
+def _forbidden() -> requests.Response:
+    """Build the 403 ServiceTitan returns for an unlicensed module."""
+    response = requests.Response()
+    response.status_code = HTTPStatus.FORBIDDEN
+    response.url = "https://api.servicetitan.io/pricebook/v2/tenant/123456789/discounts-and-fees"
+    response._content = json.dumps(  # noqa: SLF001
+        {"title": "Tenant is not authorized to access this resource."}
+    ).encode()
+    return response
+
+
+def _stream(*, skip: bool) -> DiscountsAndFeesStream:
+    tap = TapServiceTitan(
+        config={**BASE_CONFIG, "skip_unentitled_streams": skip},
+        validate_config=False,
+    )
+    stream = DiscountsAndFeesStream(tap)
+    # Bypass the OAuth round-trip; these tests never reach a real endpoint.
+    stream.__dict__["authenticator"] = None
+    return stream
+
+
+def _request_raising_403(stream: DiscountsAndFeesStream) -> None:
+    """Make the stream's HTTP call surface a 403 the way a real one would."""
+
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        stream.validate_response(_forbidden())
+
+    stream._request = _raise  # type: ignore[method-assign]  # noqa: SLF001
+
+
+def test_403_is_fatal_by_default() -> None:
+    """Without the flag, a 403 still fails the run loudly."""
+    with pytest.raises(FatalAPIError):
+        _stream(skip=False).validate_response(_forbidden())
+
+
+def test_403_skips_stream_when_enabled(caplog: pytest.LogCaptureFixture) -> None:
+    """With the flag, the stream yields nothing and logs a warning."""
+    stream = _stream(skip=True)
+    _request_raising_403(stream)
+
+    with caplog.at_level("WARNING"):
+        assert list(stream.request_records(None)) == []
+
+    assert "not entitled" in caplog.text
+    assert stream.name in caplog.text
+
+
+def test_403_leaves_bookmark_untouched() -> None:
+    """A skipped stream must not advance state."""
+    stream = _stream(skip=True)
+    before = dict(stream.stream_state)
+    _request_raising_403(stream)
+    list(stream.request_records(None))
+
+    assert dict(stream.stream_state) == before
+
+
+@pytest.mark.parametrize("status", [HTTPStatus.UNAUTHORIZED, HTTPStatus.NOT_FOUND])
+def test_other_4xx_still_fatal(status: HTTPStatus) -> None:
+    """Only 403 is treated as an entitlement signal; 401 is auth, not licensing."""
+    response = requests.Response()
+    response.status_code = status
+    response.url = "https://api.servicetitan.io/pricebook/v2/tenant/123456789/discounts-and-fees"
+    response._content = b"{}"  # noqa: SLF001
+
+    with pytest.raises(FatalAPIError):
+        _stream(skip=True).validate_response(response)


### PR DESCRIPTION
> **Draft — opened for design review, not for merge.** @edgarrmondragon I'd value your read on the approach before this goes anywhere.

## Problem

ServiceTitan returns 403 when a tenant has not licensed the module backing an endpoint — Marketing Pro, WBS budget codes, and others. Today that fails the whole run, so anyone syncing a fleet of tenants with differing module subscriptions has to maintain a bespoke `_select` list per tenant.

That is fragile in a specific way: the lists are long, near-identical, and hand-maintained, so a stream can silently disappear from one of them and nothing errors. Being able to share a single selection across tenants removes the class of problem.

## Approach

Adds a `skip_unentitled_streams` config option. When enabled, a 403 raises an internal `StreamNotEntitledError` from `validate_response`, which `request_records` catches, logs as a warning, and swallows by ending the generator. The stream yields no records; the run continues.

~50 lines in `client.py`, one config property, five tests.

## Deliberate constraints, all worth arguing with

- **Off by default.** Silently skipping streams would also mask a genuine loss of OAuth scope, so opting in has to be a decision someone makes.
- **403 only.** 401 is authentication rather than licensing and still fails loudly. Test asserts 401 and 404 still raise `FatalAPIError`.
- **State untouched.** Ending the generator leaves the bookmark alone, so a tenant that later licenses the module resumes rather than re-syncing from `start_date`. Covered by a test.
- **Internal control flow only.** `StreamNotEntitledError` never escapes the tap.

## The question I'd most like your opinion on

I match the **bare 403 status**, not ServiceTitan's error payload. `response_error_message` already parses the `title` field, so matching on that would let us distinguish "module not licensed" from "token lacks scope" — a meaningfully better signal. I didn't do it because I'm not confident those strings are stable across endpoints or over time, and a brittle string match fails in the worst direction: it would treat a real permissions regression as a skippable entitlement gap.

If you know those payloads to be stable, I'd rather match on them.

## Not done, deliberately

No tap-level summary of skipped streams at end of run. Right now a skip is a per-stream warning that is easy to lose in a long log. It feels worth adding, but I didn't want to reach into the tap lifecycle without asking first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)